### PR TITLE
Fixes for #2798 and #2800

### DIFF
--- a/yamj/src/main/java/com/moviejukebox/plugin/ImdbPlugin.java
+++ b/yamj/src/main/java/com/moviejukebox/plugin/ImdbPlugin.java
@@ -174,7 +174,7 @@ public class ImdbPlugin implements MovieDatabasePlugin {
         }
 
         // PATTERN
-        pRelease = Pattern.compile("(?:.*?)\\Q" + preferredCountry + "\\E(?:.*?)\\Qrelease_date\">\\E(.*?)(?:<.*?>)(.*?)(?:</a>.*)");
+        pRelease = Pattern.compile(">\\Q" + preferredCountry + "\\E<.*?\"release_date\">([^<]+)<.*");
 
     }
 
@@ -592,6 +592,12 @@ public class ImdbPlugin implements MovieDatabasePlugin {
 
             // This plot didn't work, look for another version
             if (isNotValidString(xmlPlot)) {
+                xmlPlot = HTMLTools.extractTag(xml, "<div class=\"summary_text\">", HTML_DIV_END);
+                xmlPlot = HTMLTools.removeHtmlTags(xmlPlot).trim();
+            }
+
+            // This plot didn't work, look for another version
+            if (isNotValidString(xmlPlot)) {
                 xmlPlot = HTMLTools.extractTag(xml, "<div class=\"inline canwrap\" itemprop=\"description\">", HTML_DIV_END);
                 xmlPlot = HTMLTools.removeHtmlTags(xmlPlot).trim();
             }
@@ -696,7 +702,7 @@ public class ImdbPlugin implements MovieDatabasePlugin {
 
             // "contains" is a quick match before the slower find() is triggered.
             if (releaseInfoXML.contains(preferredCountry) && mRelease.find()) {
-                String releaseDate = mRelease.group(1) + " " + mRelease.group(2);
+                String releaseDate = mRelease.group(1);
                 movie.setReleaseDate(releaseDate, IMDB_PLUGIN_ID);
             }
         }

--- a/yamj/src/main/java/com/moviejukebox/tools/DateTimeTools.java
+++ b/yamj/src/main/java/com/moviejukebox/tools/DateTimeTools.java
@@ -231,7 +231,12 @@ public final class DateTimeTools {
             }
         }
 
-        return parseDateTime(parsedDateString);
+        Date parsedDate = parseDateTime(parsedDateString);
+        if (parsedDate == null) {
+            throw new IllegalArgumentException("Date string '" + parsedDateString + "' cannot be parsed to a date");
+        }
+
+        return parsedDate;
     }
 
     private static Date parseDateTime(String convertDate) {


### PR DESCRIPTION
With this commit YAMJ stops throwing NullPointerExceptions' on malformed release dates scraped from IMDB; this was one of the main reasons for random fields left as UNKNOWN. At the same time, fixed extraction of release dates and made the regex search faster.

Also added a new pattern for extracting plots from IMDB - this should fix many other complains of unscraped plots.

Note: failing tests were also failing before this commit, in exactly the same way.